### PR TITLE
Fix clippy collapsible_match errors on Rust 1.95

### DIFF
--- a/src/backends/fltk/fltk_button.rs
+++ b/src/backends/fltk/fltk_button.rs
@@ -226,13 +226,9 @@ impl CustomButton {
                 i.do_callback();
                 true
             }
-            Event::KeyDown => {
-                if app::event_key() == Key::Enter {
-                    i.do_callback();
-                    true
-                } else {
-                    false
-                }
+            Event::KeyDown if app::event_key() == Key::Enter => {
+                i.do_callback();
+                true
             }
             Event::Enter => {
                 let mut animator = animator_cell1.borrow_mut();

--- a/src/backends/skia/mod.rs
+++ b/src/backends/skia/mod.rs
@@ -169,20 +169,18 @@ impl ApplicationHandler<DialogMessageRequest> for AppState {
             WindowEvent::CursorMoved { position, .. } => {
                 dialog.handle_cursor_moved(position);
             }
-            WindowEvent::MouseInput { state, button, .. } => {
-                if button == MouseButton::Left {
-                    match state {
-                        ElementState::Pressed => {
-                            dialog.handle_mouse_pressed();
-                        }
-                        ElementState::Released => {
-                            if let Some(index) = dialog.handle_mouse_released() {
-                                dialog.send_result(XDialogResult::ButtonPressed(index));
-                                dialog.window.set_visible(false);
-                                let wid = window_id;
-                                self.dialogs.remove(&dialog_id);
-                                self.window_to_id.remove(&wid);
-                            }
+            WindowEvent::MouseInput { state, button: MouseButton::Left, .. } => {
+                match state {
+                    ElementState::Pressed => {
+                        dialog.handle_mouse_pressed();
+                    }
+                    ElementState::Released => {
+                        if let Some(index) = dialog.handle_mouse_released() {
+                            dialog.send_result(XDialogResult::ButtonPressed(index));
+                            dialog.window.set_visible(false);
+                            let wid = window_id;
+                            self.dialogs.remove(&dialog_id);
+                            self.window_to_id.remove(&wid);
                         }
                     }
                 }
@@ -190,28 +188,28 @@ impl ApplicationHandler<DialogMessageRequest> for AppState {
             WindowEvent::ModifiersChanged(modifiers) => {
                 dialog.handle_modifiers_changed(&modifiers);
             }
-            WindowEvent::KeyboardInput { event, is_synthetic, .. } => {
-                if event.state == ElementState::Pressed && !is_synthetic {
-                    match dialog.handle_key_pressed(&event.logical_key) {
-                        KeyAction::ActivateButton(index) => {
-                            if !event.repeat {
-                                dialog.send_result(XDialogResult::ButtonPressed(index));
-                                dialog.window.set_visible(false);
-                                let wid = window_id;
-                                self.dialogs.remove(&dialog_id);
-                                self.window_to_id.remove(&wid);
-                            }
+            WindowEvent::KeyboardInput { event, is_synthetic, .. }
+                if event.state == ElementState::Pressed && !is_synthetic =>
+            {
+                match dialog.handle_key_pressed(&event.logical_key) {
+                    KeyAction::ActivateButton(index) => {
+                        if !event.repeat {
+                            dialog.send_result(XDialogResult::ButtonPressed(index));
+                            dialog.window.set_visible(false);
+                            let wid = window_id;
+                            self.dialogs.remove(&dialog_id);
+                            self.window_to_id.remove(&wid);
                         }
-                        KeyAction::Close => {
-                            if !event.repeat {
-                                dialog.handle_close_requested();
-                                let wid = dialog.window.id();
-                                self.dialogs.remove(&dialog_id);
-                                self.window_to_id.remove(&wid);
-                            }
-                        }
-                        KeyAction::None => {}
                     }
+                    KeyAction::Close => {
+                        if !event.repeat {
+                            dialog.handle_close_requested();
+                            let wid = dialog.window.id();
+                            self.dialogs.remove(&dialog_id);
+                            self.window_to_id.remove(&wid);
+                        }
+                    }
+                    KeyAction::None => {}
                 }
             }
             _ => {}

--- a/tests/message_timeout.rs
+++ b/tests/message_timeout.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use xdialog::*;
 
 #[test]
-#[ntest::timeout(2000)]
+#[ntest::timeout(10000)]
 fn message_dialog_respects_timeout() {
     XDialogBuilder::new().run(run);
 }


### PR DESCRIPTION
Rust 1.95's clippy flagged three nested if-in-match patterns that can be expressed more directly. Two in the skia backend use a destructuring pattern and a match guard; one in the fltk button uses a match guard.