### PR TITLE
Fix Supply Chain CI: ignore unreachable quick-xml DoS advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,14 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
     "RUSTSEC-2024-0436", # paste unmaintained (dev-only: xcap -> image -> rav1e)
     "RUSTSEC-2026-0192", # ttf-parser unmaintained (transitive: cosmic-text/fontdb/rustybuzz + winit sctk-adwaita); no replacement adopted upstream
+    # quick-xml < 0.41.0 DoS advisories (quadratic attribute check + unbounded NsReader
+    # namespace allocation). Only reachable when parsing untrusted XML; both paths here
+    # parse trusted, crate-bundled protocol definitions at build time: wayland-scanner
+    # (^0.39, pinned via winit 0.30.x) generates code from Wayland protocol XML, and xcb
+    # (dev-only build-dep via xcap) parses the X11 protocol XML. No untrusted runtime
+    # input, and no upgrade is available without replacing the winit-pinned wayland stack.
+    "RUSTSEC-2026-0194", # quick-xml quadratic attribute-check DoS (build-time codegen: wayland-scanner + dev-only xcb)
+    "RUSTSEC-2026-0195", # quick-xml NsReader memory-exhaustion DoS (build-time codegen: wayland-scanner + dev-only xcb)
 ]
 
 [licenses]


### PR DESCRIPTION
## Why the Supply Chain job is failing

The `Supply Chain` job runs `cargo deny check advisories`, which started failing on newly published advisories against **`quick-xml < 0.41.0`**:

- **RUSTSEC-2026-0194** — quadratic run time when checking a start tag for duplicate attribute names (CPU-exhaustion DoS).
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS). This one landed in the advisory DB after the last CI run, so it only surfaced once 0194 was addressed.

Both fire on two transitive copies of quick-xml in the tree: `0.39.4` and `0.30.0`.

## Why an upgrade isn't possible

`quick-xml >= 0.41.0` fixes both, but it can't be pulled in:

```
quick-xml v0.39.4
└── wayland-scanner v0.31.10  (requires quick-xml = "^0.39", excludes 0.41)
    └── ... winit v0.30.13 → xdialog
```

`wayland-scanner 0.31.10` pins `quick-xml = "^0.39"`, and the whole wayland stack is pinned by `winit 0.30.13`. Bumping quick-xml would require replacing the entire winit-pinned wayland stack.

## Why it's safe to ignore

Both advisories only affect **parsing of untrusted XML**. In this crate, quick-xml is only reached on build-time paths over trusted, crate-bundled input:

- `wayland-scanner` (proc-macro) generates code from the bundled Wayland protocol XML at build time.
- `xcb` — a **dev-only build-dependency** via `xcap` — parses the X11 protocol XML at build time.

No untrusted runtime XML is ever handed to quick-xml, so neither DoS is reachable.

## Change

Add both advisory IDs to the `ignore` list in `deny.toml` with a justification comment, consistent with the existing entries. Verified locally that `cargo deny --all-features check advisories`, `licenses`, `bans`, and `sources` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014JQhuuZGmCaHNzMRwHnBQG)_