### PR TITLE
Fix CI: clippy for_kv_map lint and RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2038,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/src/backends/win32/taskdialog.rs
+++ b/src/backends/win32/taskdialog.rs
@@ -161,7 +161,7 @@ impl TaskDialogManager {
 
     pub fn close_all(&self) {
         let mut dialogs = self.open_dialogs.lock().unwrap_or_else(|e| e.into_inner());
-        for (_id, obj) in dialogs.iter_mut() {
+        for obj in dialogs.values_mut() {
             let _ = obj.0.send(DialogRequest::Close);
         }
     }


### PR DESCRIPTION
Fixes the two failing CI jobs seen on recent runs (e.g. the renovate PRs):

- **Clippy (Windows)**: new stable clippy flags `for (_id, obj) in dialogs.iter_mut()` with `clippy::for_kv_map` in `src/backends/win32/taskdialog.rs` — switched to `dialogs.values_mut()`.
- **Supply Chain**: RUSTSEC-2026-0204 (invalid pointer dereference in `crossbeam-epoch` `fmt::Pointer` impl) — updated `crossbeam-epoch` 0.9.18 -> 0.9.20 in the lockfile. Also bumped the yanked `num-bigint` 0.4.7 -> 0.4.8 to clear the cargo-deny yanked-crate warning.

Verified locally: `cargo clippy --locked --all-targets -- -D warnings` and `cargo deny --all-features check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiHTYPXvw8Efc2DLt5i86e